### PR TITLE
fix: align dash policy, exempt range en dashes, repair validation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Use this skill when an agent needs to improve:
 
 ## Installation
 
-The [skills.sh CLI](https://www.skills.sh/docs/cli) is the easiest way to install the skill once the repository is public.
+The [skills.sh CLI](https://www.skills.sh/docs/cli) is the easiest way to install the skill.
 
 With `npx`:
 
@@ -120,10 +120,11 @@ Use my writing sample below as the voice reference, then rewrite the article int
 
 ## Validation
 
-Validate the skill with the standard skill creator checker:
+Validate the skill with the checker from Anthropic's [skill-creator](https://github.com/anthropics/skills/tree/main/skills/skill-creator) skill:
 
 ```bash
-python3 /path/to/skill-creator/scripts/quick_validate.py /path/to/better-writing
+git clone https://github.com/anthropics/skills.git
+python3 skills/skills/skill-creator/scripts/quick_validate.py /path/to/better-writing
 ```
 
 This checks the required skill metadata and naming rules.

--- a/SKILL.md
+++ b/SKILL.md
@@ -48,7 +48,7 @@ Match the user's requested deliverable.
 
 When the user asks to "humanise", "de-AI", "remove slop", "make this sound less ChatGPT", or similar, use a stricter pass:
 
-- Remove em dashes and en dashes by default. Use sentence breaks, commas, colons, parentheses, or regular hyphens.
+- Remove em dashes and en dashes by default. Use sentence breaks, commas, colons, parentheses, or regular hyphens. Keep en dashes in numeric and date ranges.
 - Remove decorative emojis, mechanical bold labels, title-case headings, and inline-header bullet lists unless the target medium expects them.
 - Remove "let me know", "here is", "of course", knowledge-cutoff disclaimers, and other pasted chatbot artefacts.
 - Remove vague positive endings. End on the real point.

--- a/references/ai-writing-patterns.md
+++ b/references/ai-writing-patterns.md
@@ -81,7 +81,7 @@ Fix by using the simpler verb when it is accurate.
 
 ### Negative Parallelism
 
-The text uses a predictable contrast structure.
+The text uses a predictable contrast structure. The same pattern appears as "Binary Contrast" in `structures-and-phrases.md`; keep the two lists in sync.
 
 Watch for:
 
@@ -121,7 +121,7 @@ Fix by naming the actor when it matters. Keep passive voice when the actor is un
 
 AI prose often leans on em dashes and en dashes for rhythm and faux sophistication.
 
-Default fix: remove them in rewrites. Use a period, comma, colon, parentheses, or regular hyphen.
+In normal rewrites, treat heavy dash use as one tell among others and thin it out only when it clusters with other patterns. In strict "humanise" or de-AI passes, remove em and en dashes by default, using a period, comma, colon, parentheses, or regular hyphen instead. Keep en dashes in numeric and date ranges such as "2019–2024" or "pages 10–12"; that is standard typography, not an AI tell.
 
 ### Mechanical Bold and Inline Headers
 

--- a/references/preflight.md
+++ b/references/preflight.md
@@ -15,7 +15,7 @@ Run this before delivery.
 - No chatbot framing remains.
 - No generic "in conclusion" ending remains unless the genre requires it.
 - No decorative emoji or mechanical bold-label bullets remain unless appropriate.
-- No em dashes or en dashes remain in strict de-AI rewrites.
+- No em dashes or en dashes remain in strict de-AI rewrites, except en dashes in numeric and date ranges.
 - No "not just X but Y" scaffold remains.
 - No vague "experts say" claim remains without a named source.
 - No promotional language remains in neutral copy.

--- a/references/structures-and-phrases.md
+++ b/references/structures-and-phrases.md
@@ -72,6 +72,8 @@ Name the implication, stake, reason, issue, or behaviour.
 
 ### Binary Contrast
 
+The same pattern appears as "Negative Parallelism" in `ai-writing-patterns.md`; keep the two lists in sync.
+
 These patterns feel pre-baked:
 
 - "Not because X. Because Y."


### PR DESCRIPTION
- Scope default dash removal to strict de-AI passes in ai-writing-patterns.md,
  matching SKILL.md, and exempt en dashes in numeric and date ranges everywhere
- Link the validator to anthropics/skills skill-creator with a runnable command
- Drop stale 'once the repository is public' phrasing from the README
- Cross-reference the duplicated contrast pattern between the two references

https://claude.ai/code/session_01J6Tn8RZLfmyh4Jce6oEYN7