### PR TITLE
Refresh AI-writing catalogue: tiers, evidence-backed guardrails, genre tells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 The pattern lists in `references/` are a living catalogue, not a fixed rulebook. AI writing tells drift as models change, so additions, changes, and retirements are dated here. When a tell fades from current model output, mark it as legacy in the reference rather than deleting it, so the skill still catches older drafts.
 
+## 2026-06-15
+
+Catalogue refresh informed by 2024–2026 corpus research (Kobak, Liang, Zhao excess-vocabulary studies; the CMU/Reinhart grammar study; the current Wikipedia "Signs of AI writing" catalogue; detector false-positive research).
+
+### Added
+
+- A decision procedure and three confidence tiers in `references/ai-writing-patterns.md`, so "look for clusters, not isolated quirks" is now quantitative.
+- A "Near-Conclusive Artefacts" section: leaked tool markup (`oaicite`, `contentReference`, and similar), raw markdown in plain-text destinations, tracking parameters, unedited chatbot scaffolding, and unfilled placeholders. These are hard evidence and need no corroboration.
+- A "Nominalisation and Noun Density" pattern, a "Sycophancy" entry (2025-era), and diagnostic-only model fingerprints.
+- New stock openers, mechanical transitions, and essay-scaffold closers in `references/structures-and-phrases.md`, plus structures: isn't-just escalation, countdown/tail negation, rhetorical self-answer, over-signposting, false balance, list-itis, fractal recap, invented compound jargon, aphorism formula, meta-commentary joiners, and engagement bait. Each carries a genre exemption.
+- A new reference, `references/genre-tells.md`: concrete phrase banks and exemptions for email, social, marketing/SEO, academic, and code/PR/docs.
+- Structure checks in `references/preflight.md`: uniform-cadence, paragraph-reshuffle, and friction-free-tone, the last worded to surface existing tone rather than invent it.
+- Three eval fixtures: `chatbot-artefacts`, `over-signposting`, and `plain-human` (a false-positive regression that fails if a lone `delve` or em dash is over-edited).
+
+### Changed
+
+- The overused-vocabulary list is now era-stamped and tiered. Spoken-English-only and ordinary-English words that over-flag were removed or demoted to the corpus-only tier.
+- The False Positives section now carries the detector equity data (Stanford 61% non-native false-positive rate; retired OpenAI classifier; the Constitution flagged as AI) and states plainly that detector-evasion is a non-goal.
+- The em-dash guidance across `SKILL.md`, `references/ai-writing-patterns.md`, and `references/preflight.md` is reframed: the em dash is the least reliable single tell, removal in a strict pass is a register choice, not detector-evasion.
+
+### Marked legacy
+
+- The 2023 GPT-4 vocabulary set (delve, tapestry, testament, intricate, meticulous, pivotal, underscore, realm, showcase) peaked in 2023–early 2024 and is declining as models adapt. It is kept for older drafts, but its absence does not clear a text.
+- The standalone model disclaimers ("As an AI language model", "As of my last update") are 2022–2024-era and largely retired; conclusive when present, but their absence proves nothing.
+
 ## 2026-06-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Better Writing is an agent skill for rewriting, drafting, and reviewing prose. M
 On top of that, it does the expected job well:
 
 - AI-sounding patterns such as significance inflation, vague attribution, promotional padding, and formulaic conclusions
-- slop structures such as throat-clearing, binary contrast, false agency, and manufactured drama
+- slop structures such as throat-clearing, binary contrast, false agency, over-signposting, and manufactured drama
+- confidence tiers and a near-conclusive-artefact check, so a single quirk never triggers an edit but leaked tool markup or an unfilled `[Your Name]` placeholder does
 - a final pre-flight check before delivery
 
 It also ships with an [evaluation harness](./evals/) so changes to the pattern lists can be regression-tested instead of vibe-checked.
@@ -145,11 +146,12 @@ Use my writing sample below as the voice reference, then rewrite the article int
 | --- | --- |
 | [SKILL.md](./SKILL.md) | Core skill instructions and metadata. |
 | [agents/openai.yaml](./agents/openai.yaml) | UI metadata for compatible agent clients. |
-| [references/ai-writing-patterns.md](./references/ai-writing-patterns.md) | AI-writing tells and false-positive checks. |
+| [references/ai-writing-patterns.md](./references/ai-writing-patterns.md) | AI-writing tells, confidence tiers, near-conclusive artefacts, and false-positive checks. |
 | [references/preflight.md](./references/preflight.md) | Final quality checks before delivery. |
 | [references/sources.md](./references/sources.md) | Source projects and attribution notes. |
 | [references/structures-and-phrases.md](./references/structures-and-phrases.md) | Slop phrase and structure audit. |
-| [references/voice-and-context.md](./references/voice-and-context.md) | Audience, genre, dials, and voice calibration. |
+| [references/genre-tells.md](./references/genre-tells.md) | Genre-specific phrase banks for email, social, marketing, academic, and code. |
+| [references/voice-and-context.md](./references/voice-and-context.md) | Audience, genre, dials, voice calibration, and genre exemptions. |
 | [evals/](./evals/) | Fixture texts and a checker for regression-testing the skill. |
 | [CHANGELOG.md](./CHANGELOG.md) | Dated history of the pattern catalogue. |
 
@@ -202,8 +204,10 @@ See [evals/README.md](./evals/README.md) for the full workflow. Run it before an
 
 AI tells drift. "Delve" and "tapestry" marked 2023-era output; "it's not just X, it's Y" and dash dependence mark 2025-era output. The pattern lists in `references/` are treated as a dated catalogue, not a fixed rulebook:
 
+- The vocabulary list is era-stamped and tiered, so the skill leans on cluster density and structure rather than any single word. Distinctive markers, common-but-overused words, and ordinary English that only shows up across a corpus are flagged differently.
 - Additions, changes, and retirements are dated in [CHANGELOG.md](./CHANGELOG.md).
 - Patterns that fade from current model output get marked as legacy rather than deleted, so the skill still catches older drafts.
+- The false-positive guardrails carry the detector-bias evidence (non-native and neurodivergent over-flagging), and the `plain-human` eval fails if the skill over-edits clean human prose. Detector-evasion is explicitly a non-goal.
 - Pull requests adding newly observed tells are welcome. Bring at least one real example and a false-positive note.
 
 ## Compatibility

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,9 @@ Use this skill to make prose stronger without flattening the writer. The goal is
 3. Audit the text.
    - For AI-writing tells, use `references/ai-writing-patterns.md`.
    - For slop phrases and formulaic structures, use `references/structures-and-phrases.md`.
-   - Look for clusters of tells, not isolated quirks. Do not destroy valid style just because it is polished.
+   - For genre-specific fingerprints and exemptions, use `references/genre-tells.md`.
+   - Work in order: scan for near-conclusive artefacts first; then count clustered tells in context; then apply genre exemptions; never edit on a single feature.
+   - Look for clusters of tells, not isolated quirks. The most durable tell is uniform tone that never adapts to audience or genre. Do not destroy valid style just because it is polished.
 
 4. Rewrite.
    - Keep the meaning and coverage unless the user asks for cuts.
@@ -48,7 +50,7 @@ Match the user's requested deliverable.
 
 When the user asks to "humanise", "de-AI", "remove slop", "make this sound less ChatGPT", or similar, use a stricter pass:
 
-- Remove em dashes and en dashes by default. Use sentence breaks, commas, colons, parentheses, or regular hyphens. Keep en dashes in numeric and date ranges.
+- Remove em dashes and en dashes when this pass is requested, using sentence breaks, commas, colons, parentheses, or regular hyphens; keep en dashes in numeric and date ranges. This is a register choice, not detector-evasion. See `references/ai-writing-patterns.md` for the full dash policy, including the lighter touch in normal rewrites.
 - Remove decorative emojis, mechanical bold labels, title-case headings, and inline-header bullet lists unless the target medium expects them.
 - Remove "let me know", "here is", "of course", knowledge-cutoff disclaimers, and other pasted chatbot artefacts.
 - Remove vague positive endings. End on the real point.
@@ -73,8 +75,9 @@ When the user asks to "humanise", "de-AI", "remove slop", "make this sound less 
 
 ## References
 
-- `references/voice-and-context.md`: audience, genre, dials, and voice calibration.
-- `references/ai-writing-patterns.md`: AI-writing tells and false-positive checks.
+- `references/voice-and-context.md`: audience, genre, dials, voice calibration, and genre exemptions.
+- `references/ai-writing-patterns.md`: AI-writing tells, confidence tiers, near-conclusive artefacts, and false-positive checks.
 - `references/structures-and-phrases.md`: slop phrase and structure audit.
+- `references/genre-tells.md`: genre-specific phrase banks for email, social, marketing, academic, and code.
 - `references/preflight.md`: final delivery checks and scoring.
 - `references/sources.md`: source projects and attribution notes.

--- a/evals/README.md
+++ b/evals/README.md
@@ -36,6 +36,9 @@ python3 evals/run_evals.py --all evals/examples
 | `quarterly-report` | Specificity without invention: the rewrite must keep the named causes and must not contain any percentage, because none was given. |
 | `release-notes` | Technical register: flags, filenames, version numbers, and exit codes stay exact while hype and diff-anchored wording go. |
 | `voice-preservation` | The inverse test: a quirky human draft must come back with its quirks intact, not flattened into a house style. |
+| `chatbot-artefacts` | Near-conclusive cleanup: pasted chatbot scaffolding, an unfilled `[Your Name]` placeholder, and a decorative emoji must go while the steps and link survive. |
+| `over-signposting` | Structural slop: ordinal signposting, stacked connectives, list-itis, and bold-label bullets go; all four facts survive. |
+| `plain-human` | The false-positive regression: a plain human note with a single `delve` and one em dash must come back essentially unchanged, not over-edited. |
 
 ## Check format
 

--- a/evals/examples/chatbot-artefacts.md
+++ b/evals/examples/chatbot-artefacts.md
@@ -1,0 +1,5 @@
+Onboarding checklist:
+
+1. Create your account at app.example.com.
+2. Verify your email address.
+3. Complete your profile so the team can reach you.

--- a/evals/examples/over-signposting.md
+++ b/evals/examples/over-signposting.md
@@ -1,0 +1,5 @@
+Hi team,
+
+The database migration runs on Saturday 12 July. The site will be down for about two hours, and we will take full backups beforehand. If anything goes wrong, we have a rollback plan ready.
+
+Please save your work before then, and tell me if you have questions.

--- a/evals/examples/plain-human.md
+++ b/evals/examples/plain-human.md
@@ -1,0 +1,1 @@
+Last Tuesday I spent four hours trying to delve into why the night-shift export kept failing. Turned out the cron job ran at 2am — right when the backup locked the table. I moved it to 3:30am and it has run clean for nine days. Not elegant, but I will take it.

--- a/evals/fixtures/chatbot-artefacts/checks.json
+++ b/evals/fixtures/chatbot-artefacts/checks.json
@@ -1,0 +1,20 @@
+{
+  "name": "chatbot-artefacts",
+  "brief": "Clean up this onboarding checklist a teammate drafted with a chatbot. Keep the steps and the link.",
+  "required": [
+    "app.example.com",
+    "verify your email",
+    "profile"
+  ],
+  "banned": [
+    "Certainly",
+    "simply follow",
+    "Rest assured",
+    "seamless",
+    "designed to be",
+    "Let me know if you need any modifications",
+    "[Your Name]",
+    "😊"
+  ],
+  "max_words_ratio": 0.9
+}

--- a/evals/fixtures/chatbot-artefacts/input.md
+++ b/evals/fixtures/chatbot-artefacts/input.md
@@ -1,0 +1,8 @@
+Certainly! Here's the onboarding checklist you requested.
+
+To get started, simply follow these steps. First, create your account at app.example.com. Second, verify your email address. Finally, complete your profile so the team can reach you.
+
+Rest assured, the whole process is designed to be seamless. Let me know if you need any modifications! 😊
+
+Best,
+[Your Name]

--- a/evals/fixtures/over-signposting/checks.json
+++ b/evals/fixtures/over-signposting/checks.json
@@ -1,0 +1,21 @@
+{
+  "name": "over-signposting",
+  "brief": "Rewrite this as a short, normal email to the team. Keep all four facts.",
+  "required": [
+    "12 July",
+    "two hours",
+    "backups",
+    "rollback"
+  ],
+  "banned": [
+    "I wanted to reach out",
+    "Firstly",
+    "Secondly",
+    "Moreover",
+    "Furthermore",
+    "That being said",
+    "**Timing:**",
+    "**Backups:**"
+  ],
+  "max_words_ratio": 0.95
+}

--- a/evals/fixtures/over-signposting/input.md
+++ b/evals/fixtures/over-signposting/input.md
@@ -1,0 +1,10 @@
+Hi team,
+
+I wanted to reach out regarding the database migration. There are several important points to consider here.
+
+- **Timing:** Firstly, the migration is scheduled for Saturday 12 July.
+- **Downtime:** Secondly, the site will be down for approximately two hours.
+- **Backups:** Moreover, full backups will be taken beforehand.
+- **Rollback:** Finally, we have a rollback plan ready in case anything goes wrong.
+
+Furthermore, please make sure your work is saved before then. That being said, let me know if you have any questions.

--- a/evals/fixtures/plain-human/checks.json
+++ b/evals/fixtures/plain-human/checks.json
@@ -1,0 +1,20 @@
+{
+  "name": "plain-human",
+  "brief": "Light copy edit for an internal note. Keep my voice.",
+  "required": [
+    "delve",
+    "Turned out",
+    "3:30",
+    "nine days",
+    "take it",
+    "—"
+  ],
+  "banned": [
+    "investigate why",
+    "robust",
+    "streamlined",
+    "in conclusion"
+  ],
+  "max_words_ratio": 1.1,
+  "min_words_ratio": 0.85
+}

--- a/evals/fixtures/plain-human/input.md
+++ b/evals/fixtures/plain-human/input.md
@@ -1,0 +1,1 @@
+Last Tuesday I spent four hours trying to delve into why the night-shift export kept failing. Turned out the cron job ran at 2am — right when the backup locked the table. I moved it to 3:30am and it has run clean for nine days. Not elegant, but I will take it.

--- a/references/ai-writing-patterns.md
+++ b/references/ai-writing-patterns.md
@@ -2,6 +2,34 @@
 
 Use this reference to find clusters of AI-generated prose. Do not treat any single pattern as proof. Many human writers use one or two of these naturally.
 
+## How to Use This Catalogue
+
+One feature is never a verdict. The reliable signal is a cluster of tells plus the absence of genre adaptation. AI prose stays at one pleasant altitude no matter the audience; human prose shifts register, takes sides, and varies its rhythm. Treat uniform tone across a whole piece as the most durable tell of all.
+
+Work in this order:
+
+1. Scan for near-conclusive artefacts. If one is present, the text is almost certainly machine-generated or pasted from a chatbot. See below.
+2. Otherwise count clustered tells in context. A passage needs several, not one. Use the confidence tiers when reading the vocabulary list.
+3. Apply genre exemptions. Passive voice in a methods section, bullet lists in release notes, hedging in legal text, and markdown in a README are correct, not tells. See `voice-and-context.md` and `genre-tells.md`.
+4. Never trigger an edit on a single feature. Detector-evasion is not the goal; clarity and fit are.
+
+Confidence tiers, used throughout this file:
+
+- Tier 1: distinctive markers. Flag when two or more appear in the same passage.
+- Tier 2: common but overused. Flag only at higher density, and never replace a word on sight.
+- Tier 3: ordinary English whose elevated rate shows up only across a large corpus. Do not flag or "fix" these in a single document.
+
+## Near-Conclusive Artefacts
+
+These need no corroboration. A single instance is hard evidence that text was machine-generated or pasted unedited from a chatbot. Remove them.
+
+- Leaked tool and citation markup that no human types: `oaicite`, `oai_citation`, `contentReference`, `turn0search0`, `attributableIndex`, `grok_card`, `:::writing`, `【...】` citation brackets.
+- Raw markdown dropped into a destination that does not render it: literal `**bold**`, `##` headings, or escaped `\*` asterisks in an email, a plain-text field, or a CMS that expected HTML.
+- Tracking parameters left on pasted links, such as `?utm_source=chatgpt.com`.
+- Unedited assistant scaffolding: "Let me know if you need any modifications", "Here is the revised version", "I hope this helps", "Would you like me to".
+- Unfilled template placeholders the writer forgot to replace: `[Your Name]`, `[Insert X here]`, `[Company]`, `[Date]`.
+- Standalone model disclaimers: "As an AI language model", "As a large language model", "I don't have access to real-time information". These are 2022–2024-era and largely retired by current models, so their absence proves nothing, but their presence is conclusive.
+
 ## Content Patterns
 
 ### Significance Inflation
@@ -10,8 +38,10 @@ The text overstates importance instead of explaining what happened.
 
 Watch for:
 
-- "serves as", "stands as", "testament", "pivotal", "crucial", "vital"
+- "serves as", "stands as", "plays a vital / crucial / pivotal / significant role"
+- "testament", "pivotal", "crucial", "vital", "cornerstone", "beacon"
 - "underscores its importance", "reflects broader trends", "marks a shift"
+- "left an indelible mark", "deeply rooted", "a key turning point", "a focal point"
 - vague claims about legacy, impact, or a changing landscape
 
 Fix by naming the concrete event, effect, audience, or evidence.
@@ -24,11 +54,12 @@ Fix by using the strongest relevant fact or cutting the padding.
 
 ### Superficial Present-Participle Analysis
 
-The text appends "-ing" phrases to simulate depth.
+The text appends "-ing" phrases to simulate depth. This is one of the most durable structural tells, not a vocabulary quirk: corpus studies measure present-participial clauses in LLM prose at roughly two to five times the human rate.
 
 Watch for:
 
 - "highlighting", "underscoring", "reflecting", "showcasing", "contributing to", "fostering"
+- trailing clauses tacked to the end of a sentence that restate the main clause instead of adding a fact
 
 Fix by splitting the sentence and saying the actual relationship, or remove the phrase.
 
@@ -38,8 +69,10 @@ The prose sounds like an advert when the genre needs plain description.
 
 Watch for:
 
-- "boasts", "vibrant", "rich", "profound", "renowned", "groundbreaking", "stunning", "must-visit"
-- "in the heart of", "nestled", "commitment to excellence"
+- "boasts", "vibrant", "rich", "profound", "renowned", "groundbreaking", "stunning", "must-visit", "breathtaking"
+- "in the heart of", "nestled", "commitment to excellence", "rich cultural heritage"
+- abundance metaphors: "a rich tapestry of", "woven into the tapestry", "a treasure trove of", "a myriad of", "a plethora of"
+- booster verbs in marketing copy: "supercharge", "unlock", "unleash", "empower", "elevate", "revolutionise", "transform". See `genre-tells.md`.
 
 Fix with observable facts, named features, or measured claims.
 
@@ -50,8 +83,11 @@ The text leans on faceless authority.
 Watch for:
 
 - "experts argue", "observers note", "industry reports suggest", "some critics say"
+- "studies have shown", "research suggests", "it is widely believed" with no named source
 
 Fix by naming the source, narrowing the claim, or removing it.
+
+A 2025-era variant is more dangerous than vagueness: a *real* source cited for a claim it does not actually support. Current models name genuine papers, authors, and URLs but do not verify that the source backs the sentence. When a claim leans on a specific citation, check that the source says what the text says, or flag it.
 
 ### Formulaic Challenges and Future Sections
 
@@ -63,11 +99,31 @@ Fix by keeping only real constraints, dates, decisions, and next actions.
 
 ### Overused AI Vocabulary
 
-Watch for clusters of:
+Vocabulary tells are time-dependent, so lean on structure and cluster density over any fixed word list. The eras below show how the list drifts; the absence of an older word does not clear a text.
 
-- additionally, align with, crucial, delve, enduring, enhance, foster, garner, highlight, intricate, key, landscape, pivotal, showcase, tapestry, testament, underscore, valuable, vibrant
+- 2023 (GPT-4), peaked then declined through early 2024: delve, tapestry, testament, intricate, meticulous, pivotal, underscore, realm, showcase.
+- mid-2024 (GPT-4o) shift: align with, foster, highlight, enhance, garner, ensure.
+- mid-2025 onward, subtler and narrower: enhance, emphasising, highlighting, showcasing, leverage, robust.
 
-Fix by using plainer words or rewriting the sentence around a concrete noun and verb.
+Read the list through the confidence tiers above:
+
+- Tier 1, distinctive (flag a cluster of two or more): delve, tapestry, testament, intricate, meticulous, pivotal, underscore, realm, showcase, multifaceted, myriad, plethora, commendable, paramount, burgeoning, quintessential, cornerstone, beacon, nuanced.
+- Tier 2, common but overused (flag at higher density, never replace on sight): enhance, foster, leverage, utilise, facilitate, streamline, bolster, amplify, cultivate, garner, surpass, exemplify, encompass, align with, ensure, robust, seamless, comprehensive, holistic, scalable.
+- Tier 3, ordinary English (an aggregate corpus signal only, never a single-document tell): potential, significant, crucial, key, vital, notable, important, additionally, moreover, furthermore, subsequently.
+
+Fix Tier 1 and Tier 2 clusters by using plainer words or rewriting the sentence around a concrete noun and verb. Leave Tier 3 alone in normal prose. Some Tier 2 words, such as "robust" and "scalable", carry precise technical meaning in code and documentation; keep them when accurate. See `genre-tells.md`.
+
+### Nominalisation and Noun Density
+
+AI prose buries actions inside abstract nouns, producing dense, noun-heavy sentences with weak verbs. Corpus studies find nominalisations at roughly 1.5 to 2 times the human rate.
+
+Watch for:
+
+- "the implementation of", "the utilisation of", "the optimisation of", "the facilitation of"
+- "provides an improvement in" instead of "improves"
+- strings of abstract nouns joined by "of": "the enhancement of the efficiency of the process"
+
+Fix by turning the noun back into a verb: "the implementation of X" becomes "we built X" or "implementing X". Name who did what.
 
 ### Copula Avoidance
 
@@ -76,6 +132,7 @@ The prose dodges simple "is", "are", or "has" constructions.
 Watch for:
 
 - "serves as", "stands as", "marks", "represents", "features", "boasts"
+- "refers to" used to define a subject the sentence could simply state
 
 Fix by using the simpler verb when it is accurate.
 
@@ -88,6 +145,7 @@ Watch for:
 - "not only X but Y"
 - "not just X, it is Y"
 - "this is not about X, it is about Y"
+- the escalating variant that climbs to a grand abstraction: "X isn't just Y, it's [paradigm / engine / heartbeat]"
 
 Fix by stating the point directly.
 
@@ -95,7 +153,7 @@ Fix by stating the point directly.
 
 The prose keeps packing ideas into threes.
 
-Fix by using the exact number the thought needs. Two is often enough. One strong example often beats a trio.
+Fix by using the exact number the thought needs. Two is often enough. One strong example often beats a trio. A single tricolon is a normal rhetorical device, not a tell; the signal is the habit repeating across a piece.
 
 ### Synonym Cycling
 
@@ -113,21 +171,21 @@ Fix by naming the covered topics directly.
 
 The sentence hides who acted or drops the subject.
 
-Fix by naming the actor when it matters. Keep passive voice when the actor is unknown, irrelevant, or legally sensitive.
+Fix by naming the actor when it matters. Keep passive voice when the actor is unknown, irrelevant, legally sensitive, or where the genre expects it, such as a scientific methods section.
 
 ## Formatting and Style Patterns
 
 ### Dash Dependence
 
-AI prose often leans on em dashes and en dashes for rhythm and faux sophistication.
+AI prose can lean on em dashes and en dashes for rhythm and faux sophistication. Treat this carefully: the em dash is the most-publicised tell and the least reliable. Many strong human writers use it heavily, frontier models reduced em-dash output through late 2025, and some writers now self-censor real punctuation to dodge suspicion. A single em dash, or em dashes in literary and editorial long-form, is not a tell.
 
-In normal rewrites, treat heavy dash use as one tell among others and thin it out only when it clusters with other patterns. In strict "humanise" or de-AI passes, remove em and en dashes by default, using a period, comma, colon, parentheses, or regular hyphen instead. Keep en dashes in numeric and date ranges such as "2019–2024" or "pages 10–12"; that is standard typography, not an AI tell.
+In normal rewrites, treat heavy dash use as one tell among others and thin it out only when it clusters with other patterns and clearly substitutes for sentence structure. In strict "humanise" or de-AI passes, removing em and en dashes is a register choice the user has asked for, not proof of AI origin: use a period, comma, colon, parentheses, or regular hyphen instead. Either way, keep en dashes in numeric and date ranges such as "2019–2024" or "pages 10–12"; that is standard typography. Stripping dashes to beat a detector is not a quality goal.
 
 ### Mechanical Bold and Inline Headers
 
 Watch for bullet lists where every item starts with a bold label and colon.
 
-Fix by writing normal sentences, simpler bullets, or a table when comparison matters.
+Fix by writing normal sentences, simpler bullets, or a table when comparison matters. A minor related tell: the bold label ending in a full stop instead of a colon, such as "**Speed.**" rather than "**Speed:**".
 
 ### Title-Case Headings
 
@@ -135,7 +193,7 @@ Use sentence case unless the style guide says otherwise.
 
 ### Decorative Emoji
 
-Remove decorative emoji in professional, technical, reference, and de-AI rewrites. Keep them only when the medium and voice clearly call for them.
+Remove decorative emoji in professional, technical, reference, and de-AI rewrites. Keep them only when the medium and voice clearly call for them. Section-heading emoji and emoji used as bullet markers are a strong chatbot tell.
 
 ### Curly Quotes
 
@@ -145,14 +203,23 @@ Curly quotes alone are not an AI tell. Convert to straight quotes only when the 
 
 Remove pasted chatbot behaviour:
 
-- "Of course"
-- "Certainly"
-- "Great question"
+- "Of course", "Certainly", "Sure", "Absolutely"
+- "Great question", "I'd be happy to", "Happy to help"
 - "I hope this helps"
-- "Let me know if you want"
-- "Here is an overview"
+- "Let me know if you want", "Feel free to reach out"
+- "Here is an overview", "Let me break this down for you", "Let me walk you through it"
 - "As of my last update"
 - "Based on available information" when used to pad a gap
+
+### Sycophancy
+
+A 2025-era artefact of assistant-tuned models: content-free praise before the substance.
+
+Watch for:
+
+- "You're absolutely right", "That's a brilliant question", "What a thoughtful observation"
+
+This is a tell mainly in assistant-voiced output and in finished documents where a conversational acknowledgement makes no sense. Enthusiastic humans say these things too, so flag them when they precede the real content as filler, not when they carry genuine warmth in a message.
 
 ## Filler, Hedging, and Fake Depth
 
@@ -166,18 +233,34 @@ Watch for:
 
 Fix by cutting the phrase or writing the concrete claim.
 
+## Model Fingerprints (diagnostic only)
+
+For review and diagnosis tasks, not for verdicts. These date fast and a wrong attribution is worse than none, so never act on them alone.
+
+- ChatGPT: tricolons, additive em dashes, aggressive bold, clinical vocabulary. GPT-5-era output is softer and less formal.
+- Claude: long hedged multi-clause sentences, headers everywhere, first-person politeness, "you're absolutely right".
+- Gemini: verbose, corporate-flat, plain conversational vocabulary, list and header heavy.
+
 ## False Positives
 
 Do not over-edit these without a cluster of other tells:
 
-- polished grammar
-- formal vocabulary
-- dry prose
-- one transition word
-- one dash
-- one curly quote
+- polished grammar, formal vocabulary, dry prose
+- one transition word, one dash, one curly quote
+- a single instance of a focal word such as "delve" or "intricate"
+- a single tricolon or one "not X but Y" antithesis
+- one warm "happy to help" in a genuine message
 - a common salutation or sign-off
 - clean formatting from a CMS or document editor
+
+Why single features are unreliable, and why detector-evasion is a non-goal:
+
+- Detectors are biased and brittle. A Stanford study found that more than half of non-native English essays were misclassified as AI across seven detectors, while near-native essays passed. Detectors have flagged founding documents such as the US Constitution as AI-written. OpenAI retired its own classifier in 2023 after it correctly flagged only 26% of AI text. Light paraphrasing defeats most detectors.
+- Plain, predictable, low-variation prose is the normal style of fluent non-native, formal, and neurodivergent writers. Flagging it penalises people, not machines.
+- "delve" is an RLHF artefact, not, as sometimes claimed, a marker of Nigerian English; corpus work found it does not originate there. It is common in fluent Nigerian, Indian, and other non-native business English. One or two focal words mean nothing; only a dense cluster in a short passage is a signal.
+- The em dash is the least reliable single tell. See Dash Dependence.
+
+Never strip a feature on a single signal. The job is to make the writing fit its purpose, not to make it pass a detector.
 
 ## Human Signals to Preserve
 
@@ -190,3 +273,4 @@ Preserve:
 - genuine asides and self-corrections
 - varied sentence length
 - plain repeated terms that improve clarity
+- a single em dash, a lone "delve", or one tricolon used naturally

--- a/references/genre-tells.md
+++ b/references/genre-tells.md
@@ -1,0 +1,68 @@
+# Genre Tells
+
+Concrete AI-writing fingerprints by genre, plus the exemptions that stop the general lists from over-editing a genre where a "tell" is actually correct. Apply the bank that matches the text. For dials, audience, and voice calibration, see `voice-and-context.md`.
+
+## Email and Business Messages
+
+Cut the hollow openers and framing verbs that delay the point:
+
+- "I hope this email finds you well", "Hope all is well", "Trust you are well"
+- "I wanted to reach out", "I just wanted to touch base", "Just following up", "Just checking in"
+- "Please advise", "As per my last email", "Per my previous message"
+- "Circle back", "touch base", "loop you in"
+
+Fix by leading with the reason for the message, the ask, the owner, and the date. Keep enough warmth for the relationship; direct does not mean cold.
+
+## LinkedIn and Social
+
+- broetry: one-line paragraphs stacked for drama, each on its own line.
+- engagement bait: "Agree?", "Thoughts?", "Who's with me?". See `structures-and-phrases.md`.
+- manufactured-insight hooks: "Here's what nobody tells you about", "Unpopular opinion:". See also Emphasis Crutches in `structures-and-phrases.md`.
+- themed-emoji bookending and emoji bullet markers.
+
+Fix by making one real claim and ending on it. Cut the performance.
+
+## Marketing and SEO
+
+Replace booster verbs and reveal framing with proof, usage, and outcomes:
+
+- booster verbs: "supercharge", "elevate your", "unlock the power / potential / secrets of", "harness the power of", "take it to the next level", "revolutionise the way"
+- urgency: "stay ahead of the curve", "future-proof your", "look no further", "now more than ever"
+- SEO scaffolding: "Welcome to our comprehensive guide", "The Ultimate Guide to", "Everything You Need to Know About", "Here's a breakdown of everything you need to know", keyword-stuffed headings, padded FAQ sections
+- corporate data-speak: "deliver actionable insights", "drive data-driven decisions", "leverage complex datasets"
+
+Fix with one clear promise backed by a concrete feature, number, or example. Do not invent social proof, metrics, awards, or customer names.
+
+## Academic and Scientific
+
+Tells:
+
+- excess-vocabulary stacking: "meticulously delving into the intricate", "a growing body of literature", "has garnered significant attention"
+- empty imperatives: "it is imperative", "this study sheds light on", "future research should explore"
+- vague evidence: "studies have shown", "research suggests" with no named trial, dataset, or author
+
+Fix by naming the specific study, dataset, method, or result.
+
+Exemptions, so the general lists do not damage correct scientific prose:
+
+- Hedging is bidirectional here. A genuine hedge ("these results suggest", "under these conditions") protects accuracy and should be kept, sometimes added. Do not strip it the way you would strip marketing hedging.
+- Passive voice is correct in a methods section. Do not force a human actor where the procedure is the subject.
+- A real citation for every claim is the genre norm, not padding.
+
+## Code, Pull Requests, and Documentation
+
+Tells:
+
+- comments that restate the obvious: "// loop over the items", "This function is responsible for"
+- diff-anchored prose in docs and PRs: "we added", "now we handle", "this was changed to". Documentation should describe how the system works in the present tense. This overlaps with the Documentation note in `voice-and-context.md`; keep them consistent.
+- verbose PR descriptions that narrate the diff line by line instead of stating intent and risk
+- gitmoji or emoji in commit messages where the project does not use them
+- over-defensive caveats and reimplementation of code that already exists
+
+Fix by deleting comments that repeat the code, describing behaviour in the present tense, and keeping identifiers, flags, filenames, version numbers, and exit codes exact.
+
+Exemptions:
+
+- Bullet lists, tables, and headers are correct in reference docs and release notes.
+- Markdown is correct where the destination renders it.
+- "robust", "scalable", and similar words have precise technical meaning; keep them when used accurately.

--- a/references/preflight.md
+++ b/references/preflight.md
@@ -20,6 +20,7 @@ Run this before delivery.
 - No vague "experts say" claim remains without a named source.
 - No promotional language remains in neutral copy.
 - No fake precision, invented anecdote, or made-up metric was added.
+- No leaked tool artefacts (such as `oaicite`, `contentReference`, raw `**` or `##` in a plain-text destination) and no unfilled placeholders (`[Your Name]`, `[Insert X]`) remain.
 
 ## Taste Check
 
@@ -46,6 +47,12 @@ Read the final text silently as if speaking it.
 - Where does a sentence exist only to make the piece feel complete?
 
 Fix those spots before sending.
+
+## Structure Check
+
+- Uniform cadence: do short and long sentences both appear, or does everything sit at the same 18 to 24 words? Vary the length; do not invent content to do it.
+- Paragraph-reshuffle test: could the paragraphs be reordered without breaking the flow? If so, the piece lacks connective tissue. Add the links between ideas; do not just relabel them.
+- Friction-free tone: is there any genuine spike of doubt, bluntness, humour, or irritation, or does every paragraph sit at the same pleasant altitude? Surface the tone that is already in the source or the brief. Never invent opinions, asides, or anecdotes the writer did not have.
 
 ## Delivery Check
 

--- a/references/sources.md
+++ b/references/sources.md
@@ -11,4 +11,19 @@ This skill is a new synthesis informed by these public sources:
 - `Wikipedia:Signs of AI writing`: https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing
   Observed patterns in AI-generated prose, especially significance inflation, vague attribution, promotional tone, formulaic structure, and overused vocabulary.
 
+## Corpus and detection research (2023–2025)
+
+These informed the 2026-06-15 refresh: confidence tiers, era stamping, the nominalisation and present-participle patterns, and the false-positive guardrails.
+
+- Kobak et al., "Delving into LLM-assisted writing in biomedical publications through excess vocabulary": https://arxiv.org/abs/2406.07016
+  Measured excess word usage across over 15M PubMed abstracts (2010–2024); the source of the "delve" and excess-vocabulary evidence.
+- Juzek and Ward, "Why Does ChatGPT 'Delve' So Much? Exploring the Sources of Lexical Overrepresentation in LLMs", COLING 2025: https://arxiv.org/abs/2412.11385
+  Tested and rejected the Nigerian-English hypothesis for "delve"; the basis for treating it as an RLHF artefact rather than a dialect marker.
+- Liang et al., "Mapping the Increasing Use of LLMs in Scientific Papers": https://arxiv.org/abs/2404.01268
+  Corpus estimate of LLM-modified text across arXiv, bioRxiv, and Nature journals; the realm/intricate/showcasing/pivotal vocabulary cluster.
+- Reinhart et al., "Do LLMs write like humans? Variation in grammatical and rhetorical styles", PNAS 2025: https://www.pnas.org/doi/10.1073/pnas.2422455122
+  Quantified present-participial clauses at 2–5x and nominalisations at 1.5–2x the human rate; the basis for the nominalisation and noun-density pattern.
+- Liang et al., "GPT detectors are biased against non-native English writers", Patterns 2023: https://arxiv.org/abs/2304.02819
+  Documented misclassification of non-native English writing; the basis for the false-positive guardrails and the anti-detector-evasion stance.
+
 Use these sources as diagnostic inspiration. Do not copy upstream examples or prose into user deliverables. When maintaining this skill, keep `SKILL.md` concise and move detailed pattern lists into references.

--- a/references/structures-and-phrases.md
+++ b/references/structures-and-phrases.md
@@ -19,6 +19,40 @@ Cut openers that announce the point instead of making it:
 - "Let's dive in"
 - "Let's break this down"
 
+### Stock Openers
+
+Cut the canned first lines that set a scene instead of starting the piece. These are among the most-cited AI openers across every source.
+
+- "In today's fast-paced world", "In a world where", "In an era where"
+- "In the (ever-)evolving landscape of", "In the realm of", "In the world of"
+- "Welcome to our comprehensive guide", "In this article we will explore", "In this post we'll dive into"
+- "Have you ever wondered", "Imagine", "Picture this"
+- "Buckle up", "Without further ado", "Now more than ever"
+- "Let's face it", "Let's be honest", "It's no secret that"
+
+Start with the actual subject, claim, or action instead.
+
+### Mechanical Transitions
+
+These connectives appear more often in LLM prose and tend to stack across consecutive sentences. Thin them out; most can be deleted.
+
+- "That being said", "That said", "With that in mind"
+- "This begs the question"
+- "It goes without saying", "Needless to say"
+- "In essence", "Essentially"
+
+Keep a transition only when it marks a real turn in the argument.
+
+### Essay-Scaffold Closers
+
+Cut the tell-them-what-you-told-them ending unless the genre genuinely needs a summary (a long report, a spec):
+
+- "In conclusion", "To summarise", "In summary"
+- "Overall", "Ultimately"
+- "At the end of the day"
+
+End on the real point, the next step, or the strongest detail.
+
 ### Emphasis Crutches
 
 Cut manufactured emphasis:
@@ -32,7 +66,7 @@ Cut manufactured emphasis:
 
 ### Business Jargon
 
-Prefer plain alternatives:
+Prefer plain alternatives when the word is filler. Some entries below (leverage, utilise, streamline, optimise) are Tier 2 in `ai-writing-patterns.md`: swap them when they cluster as jargon, not on sight, and keep them where they carry real meaning.
 
 | Avoid | Prefer |
 | --- | --- |
@@ -45,6 +79,16 @@ Prefer plain alternatives:
 | moving forward | next, from now on |
 | circle back | return to |
 | on the same page | agreed, aligned |
+| leverage | use |
+| utilise | use |
+| streamline | simplify, speed up |
+| optimise | improve, tune |
+| actionable | usable, specific |
+| move the needle | make a difference |
+| low-hanging fruit | easy wins |
+| synergy | working together |
+| bandwidth | time, capacity |
+| take it to the next level | improve |
 
 ### Softening and Intensifying Adverbs
 
@@ -54,7 +98,7 @@ Remove adverbs that add posture rather than meaning:
 - deeply, truly, fundamentally, inherently, inevitably
 - interestingly, importantly, crucially
 
-Keep adverbs that carry real meaning.
+Keep adverbs that carry real meaning. In personal, conversational, or voice-sample writing these often carry tone; thin them only when they cluster as filler, never on sight.
 
 ### Empty Importance
 
@@ -83,6 +127,8 @@ These patterns feel pre-baked:
 - "Not just X, but Y."
 
 Fix by stating the point directly.
+
+A specific escalating variant climbs from a modest claim to a grand abstraction, often carried by an em dash: "Support isn't just a department, it's the heartbeat of the company." Watch for the jump to a lofty noun such as "paradigm", "engine", "revolution", or "heartbeat". Fix by making the plain claim and cutting the inflation.
 
 ### Negative Listing
 
@@ -134,7 +180,7 @@ Avoid hovering above the scene:
 - "This happens because"
 - "This is why"
 
-Fix by putting the reader, actor, or specific situation in the sentence.
+Fix by putting the reader, actor, or specific situation in the sentence. Keep the distant narrator when it is a deliberate register in an essay or opinion piece.
 
 ### Question-Answer Habit
 
@@ -147,6 +193,90 @@ Fix by turning the answer into a statement, or keep the question only when it cr
 If every paragraph ends with a punchline, the rhythm becomes artificial.
 
 Fix by varying paragraph length, ending on details, and letting some paragraphs land quietly.
+
+### Countdown and Tail Negation
+
+A fixed marketing rhythm that lists negations before a payoff:
+
+- "No setup. No friction. Just results."
+- "Not X. Not Y. Just Z."
+
+Fix by naming the benefit plainly. Keep the rhythm only when it is clearly part of the writer's voice, the same caution as Dramatic Fragmentation.
+
+### Rhetorical Self-Answer
+
+A one-line question fragment answered by a fragment, used as a fake transition. Common in LinkedIn and newsletter copy:
+
+- "The result? Double the conversions."
+- "The kicker? It was free."
+- "The good news? You can start today."
+
+Fix by writing the statement.
+
+### Over-Signposting
+
+The text announces its own outline with ordinals and stacks formal connectives across paragraphs:
+
+- "Firstly... Secondly... Finally"
+- "Moreover... Furthermore... Additionally... Subsequently" piled up
+
+Fix by letting the structure carry itself and deleting most connectives. Exempt genuinely sequential or instructional genres: steps in a recipe, an install guide, or a procedure can be numbered.
+
+### False Balance
+
+Reflexive both-sidesing that never resolves, plus stacked hedges:
+
+- "On one hand X, on the other hand Y... ultimately it is complex and multifaceted."
+- "may potentially in some cases"
+
+Fix by taking a position where the genre allows confidence. Note the opposite duty in academic, legal, and medical prose, where a genuine hedge protects accuracy and should be kept or even added.
+
+### List-Itis
+
+The model defaults to bullet lists in genres that expect connected prose, fragmenting an argument into eight full-sentence bullets with no connecting reasoning. A related form is the listicle in disguise: "The first reason is cost. The second reason is speed. The third reason is reliability."
+
+Fix by writing the argument as paragraphs with real connective tissue. Exempt technical docs, release notes, reference material, and checklists, where lists are correct.
+
+### Fractal Recap
+
+The text previews itself and summarises itself at every level: an intro that lists what is coming, each section opening with its own preview and closing with its own recap, all around one thin idea.
+
+Fix by making the point once and cutting the scaffolding. Keep a single summary only in long documents that earn it.
+
+### Invented Compound Jargon
+
+The model coins official-sounding terms to manufacture authority:
+
+- "the supervision paradox", "the acceleration trap", "workload creep", "what I call the productivity paradox"
+
+Fix by describing the thing in plain words rather than naming a fake concept.
+
+### Aphorism Formula
+
+A fill-in-the-blanks faux-wisdom template:
+
+- "Trust is the currency of teams", "Data is the new oil", "Attention is the currency of the modern age", "X is the language of Y"
+
+Fix by cutting the slogan and stating what is true.
+
+### Meta-Commentary Joiners
+
+Performative interjections that narrate the writing instead of advancing it:
+
+- "Plot twist", "Spoiler", "Here's the kicker"
+- "X is a feature, not a bug", "But that's another post"
+
+Fix by making the point and trusting the reader to register it.
+
+### Engagement Bait
+
+Social-post habits that fish for a reaction:
+
+- closers: "Agree?", "Thoughts?", "Who's with me?", "Am I wrong?"
+- manufactured-insight hooks: "Here's what nobody tells you about", "Here's the truth", "Here's what nobody's saying"
+- stock templates: "Not all X are created equal", "Whether you're a X or a Y", "That's where X comes in"
+
+Fix by making a claim worth reacting to and ending on it.
 
 ## Quick Rewrite Moves
 

--- a/references/voice-and-context.md
+++ b/references/voice-and-context.md
@@ -34,6 +34,16 @@ Set these mentally before rewriting. Adjust them from the brief rather than usin
 
 ## Genre Defaults
 
+This section sets the dials and the exemptions for each genre. For the concrete phrase banks per genre, see `genre-tells.md`.
+
+A tell in one genre is correct in another. Before applying the general lists, check these exemptions:
+
+- Passive voice is correct in a scientific methods section.
+- Hedging is correct, and sometimes should be added, in academic, legal, and medical prose.
+- Bullet lists, tables, and headers are correct in technical docs, release notes, reference material, and checklists.
+- Markdown is correct where the destination renders it.
+- Words like "robust" and "scalable" have precise technical meaning; keep them when accurate.
+
 ### Emails
 
 - Lead with the action or decision.
@@ -54,6 +64,7 @@ Set these mentally before rewriting. Adjust them from the brief rather than usin
 - Avoid "elevate", "seamless", "unlock", "next-gen", and vague "transform your workflow" language.
 - Do not invent social proof, customer names, usage metrics, awards, or benchmarks.
 - Use one clear promise rather than a pile of benefits.
+- See `genre-tells.md` for the fuller bank of booster verbs and SEO scaffolding.
 
 ### Essays, Posts, and Opinion
 

--- a/skills/better-writing/references/genre-tells.md
+++ b/skills/better-writing/references/genre-tells.md
@@ -1,0 +1,1 @@
+../../../references/genre-tells.md


### PR DESCRIPTION
Research-driven update to the pattern catalogue, informed by 2024–2026 corpus studies (Kobak, Liang, Reinhart/PNAS) and detector false-positive research. A two-pass multi-agent workflow gathered the patterns and then adversarially verified the edits; every empirical claim was web-checked against its source.

## What changed

**Reliability and tiering**
- Added a decision procedure and three confidence tiers, so "look for clusters, not isolated quirks" is now quantitative.
- Replaced the flat vocabulary list with a tiered, era-stamped version. Ordinary and spoken-only words that over-flag were cut or demoted to a corpus-only tier, so the skill leans on cluster density rather than any fixed word list.

**New detection**
- `Near-Conclusive Artefacts` section: leaked tool markup (`oaicite`, `contentReference`), raw markdown in plain-text destinations, unfilled `[Your Name]` placeholders — hard evidence needing no corroboration.
- `Nominalisation and noun density` pattern, plus 2025-era structures: isn't-just escalation, over-signposting, list-itis, false balance, sycophancy, and stock openers/closers. Each carries a genre exemption.
- New `references/genre-tells.md`: per-genre phrase banks and exemptions for email, social, marketing, academic, and code.

**Guardrails (anti-over-editing)**
- Strengthened False Positives with verified detector-bias evidence (Stanford non-native bias, OpenAI's retired 26% classifier) and stated that detector-evasion is a non-goal.
- Reconciled the em-dash policy across `SKILL.md`, `ai-writing-patterns.md`, and `preflight.md`: the em dash is the least reliable tell; removal is a register choice, not detector-evasion.

**Evals**
- Three new fixtures (95 checks, all green): `chatbot-artefacts`, `over-signposting`, and `plain-human` — a false-positive regression that fails if a lone "delve" or em dash gets over-edited.

**Docs**
- CHANGELOG (dated entry; 2023-era vocab marked legacy), README, and sources updated with four verified citations.

## Testing

```bash
python3 evals/run_evals.py --all evals/examples
```

All 7 fixtures pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)